### PR TITLE
 kf-alignment-workflow-cnh: Feature/fastp adapter detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ test/
 local-test/
 !.gitignore
 !.github/
+
+data/
+*.sh
+cavatica/
+logs/
+outputs/
+params/

--- a/docs/KFDRC_SENTIEON_ALIGNMENT_GVCF_WORKFLOW_README.md
+++ b/docs/KFDRC_SENTIEON_ALIGNMENT_GVCF_WORKFLOW_README.md
@@ -62,6 +62,7 @@ that match our existing Picard metrics suite.
 |----------------------------|-----------------------|-----------------------------------|
 | Bam to Read Group (RG) BAM | samtools split        | samtools split                    |
 | RG Bam to Fastq            | biobambam2 bamtofastq | biobambam2 bamtofastq             |
+| Adapter Detection          | fastp                 | fastp                             |
 | Adapter Trimming           | cutadapt              | cutadapt                          |
 | Fastq to RG Bam            | bwa mem               | Sentieon bwa mem                  |
 | Merge RG Bams              | sambamba merge        | Sentieon ReadWriter               |

--- a/docs/KFDRC_SENTIEON_ALIGNMENT_GVCF_WORKFLOW_README.md
+++ b/docs/KFDRC_SENTIEON_ALIGNMENT_GVCF_WORKFLOW_README.md
@@ -58,6 +58,11 @@ process in the main workflow see https://github.com/childrens-bti/kf-alignment-w
 Finally, the metrics collection is done with a series of Sentieon algorithms
 that match our existing Picard metrics suite.
 
+Adapter detection is implemented with `fastp` in detection mode on a sampled
+subset of reads (up to 1M by default). This step emits JSON/HTML QC reports
+and extracts detected R1/R2 adapter sequences used to gate `cutadapt` trimming
+for paired-end and interleaved inputs.
+
 | Step                       | KFDRC GATK            | KFDRC Sentieon                    |
 |----------------------------|-----------------------|-----------------------------------|
 | Bam to Read Group (RG) BAM | samtools split        | samtools split                    |

--- a/docs/dockers_sentieon_alignment.md
+++ b/docs/dockers_sentieon_alignment.md
@@ -6,6 +6,7 @@ biobambam_bamtofastq.cwl|pgc-images.sbgenomics.com/d3b-bixu/bwa-bundle:dev
 clt_flatten_filelist.cwl|None
 clt_prepare_bwa_payload.cwl|None
 cutadapt.cwl|quay.io/biocontainers/cutadapt:4.6--py310h4b81fae_1
+fastp_adapter_detect.cwl|quay.io/biocontainers/fastp:0.23.4--h5f740d0_0
 expression_preparerg.cwl|None
 gatk_indexfeaturefile.cwl|pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R
 picard_collectgvcfcallingmetrics.cwl|pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.9R

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -66,7 +66,20 @@ steps:
 
   cutadapt:
     run: ../tools/cutadapt.cwl
-    when: $(inputs.r1_threeprime_adapter != null && ((inputs.input_reads2 == null && !inputs.interleaved) || inputs.r2_threeprime_adapter != null))
+    when: |
+      ${
+        function hasAdapter(v) {
+          if (v == null) {
+            return false;
+          }
+          var s = String(v).trim().toLowerCase();
+          return s.length > 0 && s !== "unspecified";
+        }
+        var r1ok = hasAdapter(inputs.r1_threeprime_adapter);
+        var needsR2 = (inputs.input_reads2 != null || inputs.interleaved);
+        var r2ok = hasAdapter(inputs.r2_threeprime_adapter);
+        return r1ok && (!needsR2 || r2ok);
+      }
     in:
       input_reads1:
         source: bwa_payload

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -75,8 +75,9 @@ steps:
           var s = String(v).trim().toLowerCase();
           return s.length > 0 && s !== "unspecified";
         }
+        var payload = inputs.input_reads2;
         var r1ok = hasAdapter(inputs.r1_threeprime_adapter);
-        var needsR2 = (inputs.input_reads2 != null || inputs.interleaved);
+        var needsR2 = payload != null && (payload.mates_file != null || payload.interleaved === true);
         var r2ok = hasAdapter(inputs.r2_threeprime_adapter);
         return r1ok && (!needsR2 || r2ok);
       }

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -50,6 +50,9 @@ steps:
       reads2:
         source: bwa_payload
         valueFrom: $(self.mates_file)
+      interleaved:
+        source: bwa_payload
+        valueFrom: $(self.interleaved)
       sample_name:
         source: [output_basename, bwa_payload]
         valueFrom: |
@@ -63,7 +66,7 @@ steps:
 
   cutadapt:
     run: ../tools/cutadapt.cwl
-    when: $(inputs.r1_threeprime_adapter != null && (inputs.input_reads2 == null || inputs.interleaved || inputs.r2_threeprime_adapter != null))
+    when: $(inputs.r1_threeprime_adapter != null && ((inputs.input_reads2 == null && !inputs.interleaved) || inputs.r2_threeprime_adapter != null))
     in:
       input_reads1:
         source: bwa_payload
@@ -75,13 +78,9 @@ steps:
         source: bwa_payload
         valueFrom: $(self.interleaved)
       r1_threeprime_adapter:
-        source: [fastp_adapter_detect/r1_adapter, cutadapt_r1_adapter]
-        valueFrom: |
-          $(self[0] != null ? self[0] : self[1])
+        source: fastp_adapter_detect/r1_adapter
       r2_threeprime_adapter:
-        source: [fastp_adapter_detect/r2_adapter, cutadapt_r2_adapter]
-        valueFrom: |
-          $(self[0] != null ? self[0] : self[1])
+        source: fastp_adapter_detect/r2_adapter
       minimum_length: cutadapt_min_len
       quality_base: cutadapt_quality_base
       quality_cutoff: cutadapt_quality_cutoff

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -91,10 +91,8 @@ steps:
       interleaved:
         source: bwa_payload
         valueFrom: $(self.interleaved)
-      r1_threeprime_adapter:
-        source: fastp_adapter_detect/r1_adapter
-      r2_threeprime_adapter:
-        source: fastp_adapter_detect/r2_adapter
+      r1_threeprime_adapter: fastp_adapter_detect/r1_adapter
+      r2_threeprime_adapter: fastp_adapter_detect/r2_adapter
       minimum_length: cutadapt_min_len
       quality_base: cutadapt_quality_base
       quality_cutoff: cutadapt_quality_cutoff

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -36,13 +36,34 @@ outputs:
   realgn_bam:
     type: File
     outputSource: sentieon_bwa_mem/output
-  cutadapt_stats: { type: 'File', outputSource: cutadapt/cutadapt_stats }
+  cutadapt_stats: { type: 'File?', outputSource: cutadapt/cutadapt_stats }
+  fastp_json: { type: 'File', outputSource: fastp_adapter_detect/fastp_json }
+  fastp_html: { type: 'File', outputSource: fastp_adapter_detect/fastp_html }
 
 steps:
+  fastp_adapter_detect:
+    run: ../tools/fastp_adapter_detect.cwl
+    in:
+      reads1:
+        source: bwa_payload
+        valueFrom: $(self.reads_file)
+      reads2:
+        source: bwa_payload
+        valueFrom: $(self.mates_file)
+      sample_name:
+        source: [output_basename, bwa_payload]
+        valueFrom: |
+          ${
+            var basename = self[0];
+            var rg_id = self[1].rg_str.match(/ID:[A-Za-z0-9-_/]*?([A-Za-z0-9-_]*)\\t/);
+            var reads_name = self[1].reads_file.basename.replace(/.f(ast)?[aq](\.gz)?$/, "");
+            return [basename, (rg_id != null ? rg_id[1] : "UNKNOWN"), reads_name].join('.');
+          }
+    out: [fastp_json, fastp_html, r1_adapter, r2_adapter]
+
   cutadapt:
     run: ../tools/cutadapt.cwl
-    when: |
-      $(inputs.r1_threeprime_adapter != null && (inputs.r2_threeprime_adapter != null || inputs.input_reads2.mates_file == null) && (inputs.r2_threeprime_adapter != null || !inputs.interleaved.interleaved))
+    when: $(inputs.r1_threeprime_adapter != null && (inputs.input_reads2 == null || inputs.interleaved || inputs.r2_threeprime_adapter != null))
     in:
       input_reads1:
         source: bwa_payload
@@ -53,8 +74,14 @@ steps:
       interleaved:
         source: bwa_payload
         valueFrom: $(self.interleaved)
-      r1_threeprime_adapter: cutadapt_r1_adapter
-      r2_threeprime_adapter: cutadapt_r2_adapter
+      r1_threeprime_adapter:
+        source: [fastp_adapter_detect/r1_adapter, cutadapt_r1_adapter]
+        valueFrom: |
+          $(self[0] != null ? self[0] : self[1])
+      r2_threeprime_adapter:
+        source: [fastp_adapter_detect/r2_adapter, cutadapt_r2_adapter]
+        valueFrom: |
+          $(self[0] != null ? self[0] : self[1])
       minimum_length: cutadapt_min_len
       quality_base: cutadapt_quality_base
       quality_cutoff: cutadapt_quality_cutoff

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -1,0 +1,97 @@
+cwlVersion: v1.2
+class: CommandLineTool
+id: fastp_adapter_detect
+label: "fastp v0.23.4 Adapter Detection"
+doc: |
+  Run fastp to detect adapter sequences and produce JSON and HTML QC reports.
+  Trimmed reads are discarded (/tmp); only the reports are used downstream.
+  Processes up to 1M reads by default. --detect_adapter_for_pe is added
+  automatically when reads2 is provided.
+requirements:
+  - class: ShellCommandRequirement
+  - class: DockerRequirement
+    dockerPull: 'quay.io/biocontainers/fastp:0.23.4--h5f740d0_0'
+  - class: InlineJavascriptRequirement
+  - class: ResourceRequirement
+    coresMin: $(inputs.threads)
+    ramMin: 4000
+
+baseCommand: [fastp]
+
+inputs:
+  reads1:
+    type: File
+    doc: "R1 FASTQ (or FASTQ.GZ) file"
+    inputBinding:
+      prefix: "-i"
+      position: 1
+  reads2:
+    type: 'File?'
+    doc: "R2 FASTQ (or FASTQ.GZ) file for paired-end input"
+    inputBinding:
+      prefix: "-I"
+      position: 2
+  sample_name:
+    type: string
+    doc: "Sample name used to name output reports"
+  threads:
+    type: 'int?'
+    default: 4
+    inputBinding:
+      prefix: "--thread"
+      position: 3
+  reads_to_process:
+    type: 'int?'
+    default: 1000000
+    doc: "Limit number of reads analysed (speeds up detection)"
+    inputBinding:
+      prefix: "--reads_to_process"
+      position: 4
+
+arguments:
+  - position: 5
+    shellQuote: false
+    valueFrom: $(inputs.reads2 != null ? "--detect_adapter_for_pe" : "")
+  - position: 6
+    shellQuote: false
+    valueFrom: >-
+      -h $(inputs.sample_name).fastp.html
+      -j $(inputs.sample_name).fastp.json
+      -o /tmp/fastp_discard_r1.fastq.gz
+      $(inputs.reads2 != null ? "-O /tmp/fastp_discard_r2.fastq.gz" : "")
+
+outputs:
+  fastp_json:
+    type: File
+    doc: "fastp JSON report with detected adapter sequences and QC metrics"
+    outputBinding:
+      glob: $(inputs.sample_name).fastp.json
+  fastp_html:
+    type: File
+    doc: "fastp HTML report"
+    outputBinding:
+      glob: $(inputs.sample_name).fastp.html
+  r1_adapter:
+    type: 'string?'
+    doc: "Detected R1 adapter sequence"
+    outputBinding:
+      glob: $(inputs.sample_name).fastp.json
+      loadContents: true
+      outputEval: |
+        ${
+          var ac = JSON.parse(self[0].contents).adapter_cutting || {};
+          var v = ac.read1_adapter_sequence || "";
+          return v.length > 0 ? v : null;
+        }
+  r2_adapter:
+    type: 'string?'
+    doc: "Detected R2 adapter sequence"
+    outputBinding:
+      glob: $(inputs.sample_name).fastp.json
+      loadContents: true
+      outputEval: |
+        ${
+          var ac = JSON.parse(self[0].contents).adapter_cutting || {};
+          var v = ac.read2_adapter_sequence || "";
+          return v.length > 0 ? v : null;
+        }

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -5,8 +5,9 @@ label: "fastp v0.23.4 Adapter Detection"
 doc: |
   Run fastp to detect adapter sequences and produce JSON and HTML QC reports.
   Trimmed reads are discarded (/tmp); only the reports are used downstream.
-  Processes up to 1M reads by default. --detect_adapter_for_pe is added
-  automatically when reads2 is provided.
+  Processes up to 1M reads by default.
+  - For paired-end input: provide reads2 for separate files, or set interleaved=true for interleaved file.
+  - Automatically adds --detect_adapter_for_pe when reads2 is provided or interleaved=true.
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
@@ -21,16 +22,20 @@ baseCommand: [fastp]
 inputs:
   reads1:
     type: File
-    doc: "R1 FASTQ (or FASTQ.GZ) file"
+    doc: "R1 FASTQ (or FASTQ.GZ) file, or interleaved paired-end FASTQ if interleaved=true"
     inputBinding:
       prefix: "-i"
       position: 1
   reads2:
     type: 'File?'
-    doc: "R2 FASTQ (or FASTQ.GZ) file for paired-end input"
+    doc: "R2 FASTQ (or FASTQ.GZ) file for paired-end input (set to null if interleaved=true)"
     inputBinding:
       prefix: "-I"
       position: 2
+  interleaved:
+    type: 'boolean?'
+    default: false
+    doc: "Set to true if reads1 contains interleaved paired-end reads"
   sample_name:
     type: string
     doc: "Sample name used to name output reports"
@@ -49,9 +54,12 @@ inputs:
       position: 4
 
 arguments:
+  - position: 2
+    shellQuote: false
+    valueFrom: $(inputs.interleaved ? "--interleaved_in" : "")
   - position: 5
     shellQuote: false
-    valueFrom: $(inputs.reads2 != null ? "--detect_adapter_for_pe" : "")
+    valueFrom: $(inputs.interleaved || inputs.reads2 != null ? "--detect_adapter_for_pe" : "")
   - position: 6
     shellQuote: false
     valueFrom: >-

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -56,17 +56,30 @@ inputs:
 arguments:
   - position: 2
     shellQuote: false
-    valueFrom: $(inputs.interleaved ? "--interleaved_in" : "")
+    valueFrom: |
+      $(inputs.interleaved ? "--interleaved_in" : null)
   - position: 5
     shellQuote: false
-    valueFrom: $(inputs.interleaved || inputs.reads2 != null ? "--detect_adapter_for_pe" : "")
+    valueFrom: |
+      $(inputs.interleaved || inputs.reads2 != null ? "--detect_adapter_for_pe" : null)
   - position: 6
+    prefix: "-h"
+    valueFrom: $(inputs.sample_name + ".fastp.html")
+  - position: 7
+    prefix: "-j"
+    valueFrom: $(inputs.sample_name + ".fastp.json")
+  - position: 8
+    prefix: "-o"
+    valueFrom: /tmp/fastp_discard_r1.fastq.gz
+  - position: 9
+    prefix: "-O"
+    valueFrom: |
+      $(inputs.reads2 != null ? "/tmp/fastp_discard_r2.fastq.gz" : null)
+  - position: 100
     shellQuote: false
     valueFrom: >-
-      -h $(inputs.sample_name).fastp.html
-      -j $(inputs.sample_name).fastp.json
-      -o /tmp/fastp_discard_r1.fastq.gz
-      $(inputs.reads2 != null ? "-O /tmp/fastp_discard_r2.fastq.gz" : "")
+      && sed -n 's/.*"read1_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json > r1_adapter.txt
+      && sed -n 's/.*"read2_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json > r2_adapter.txt
 
 outputs:
   fastp_json:
@@ -81,25 +94,15 @@ outputs:
       glob: $(inputs.sample_name).fastp.html
   r1_adapter:
     type: 'string?'
-    doc: "Detected R1 adapter sequence"
+    doc: "Detected R1 adapter sequence (empty file => null)"
     outputBinding:
-      glob: $(inputs.sample_name).fastp.json
+      glob: r1_adapter.txt
       loadContents: true
-      outputEval: |
-        ${
-          var ac = JSON.parse(self[0].contents).adapter_cutting || {};
-          var v = ac.read1_adapter_sequence || "";
-          return v.length > 0 ? v : null;
-        }
+      outputEval: $(self[0].contents.trim() || null)
   r2_adapter:
     type: 'string?'
-    doc: "Detected R2 adapter sequence"
+    doc: "Detected R2 adapter sequence (empty file => null)"
     outputBinding:
-      glob: $(inputs.sample_name).fastp.json
+      glob: r2_adapter.txt
       loadContents: true
-      outputEval: |
-        ${
-          var ac = JSON.parse(self[0].contents).adapter_cutting || {};
-          var v = ac.read2_adapter_sequence || "";
-          return v.length > 0 ? v : null;
-        }
+      outputEval: $(self[0].contents.trim() || null)

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -487,5 +487,5 @@ hints:
 - GVCF
 - SENTIEON
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-alignment-workflow-cnh'
+- id: 'https://github.com/childrens-bti/kf-alignment-workflow-cnh/releases/tag/v1.1.0'
   label: github-release

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -201,6 +201,10 @@ outputs:
       calculate contamination."}
   cutadapt_stats: {type: 'File[]?', outputSource: sentieon_bwa_mem_payloads/cutadapt_stats, doc: "Stats from Cutadapt activity on
       inputs."}
+  fastp_adapter_json: {type: 'File[]?', outputSource: sentieon_bwa_mem_payloads/fastp_json, doc: "fastp adapter detection JSON
+      reports for each payload."}
+  fastp_adapter_html: {type: 'File[]?', outputSource: sentieon_bwa_mem_payloads/fastp_html, doc: "fastp adapter detection HTML
+      reports for each payload."}
   bqsr_report: {type: File, outputSource: sentieon_bqsr/recal_table, doc: "Recalibration report from BQSR."}
   gvcf_calling_metrics: {type: 'File[]?', outputSource: generate_gvcf/gvcf_calling_metrics, doc: "General metrics for gVCF calling
       quality."}
@@ -348,7 +352,7 @@ steps:
         pickValue: all_non_null
       bwa_cpu: bwa_cpu
       bwa_ram: bwa_ram
-    out: [realgn_bam, cutadapt_stats]
+    out: [realgn_bam, cutadapt_stats, fastp_json, fastp_html]
   sentieon_markdups:
     run: ../tools/sentieon_dedup.cwl
     in:
@@ -483,5 +487,5 @@ hints:
 - GVCF
 - SENTIEON
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-alignment-workflow-cnh/releases/tag/v1.0.0'
+- id: 'https://github.com/childrens-bti/kf-alignment-workflow-cnh'
   label: github-release


### PR DESCRIPTION
## Summary
- Closes [#755](https://github.com/childrens-bti/internal-ticket-tracker/issues/775)
- Introduces automated adapter detection via `fastp` in the Sentieon alignment workflow, wiring detected adapters into `cutadapt` and exposing fastp JSON/HTML reports as workflow outputs.
- Updates Sentieon docs/docker tables accordingly and includes a separate `.gitignore` cleanup commit.

## Changes

### feat: add interleaved support to fastp_adapter_detect
- Added `interleaved` boolean input to `fastp_adapter_detect`
- Passes `--interleaved_in` to fastp when `interleaved=true`, enabling proper PE adapter detection from a single interleaved FASTQ
- Updated `--detect_adapter_for_pe` to trigger for both interleaved and split PE inputs
- Wired `bwa_payload.interleaved` into the `fastp_adapter_detect` step in `bwa_payload_to_realn_bam`

### fix: cutadapt when — Cavatica payload shape, adapter gating, and interleaved support
- Cavatica evaluates `when` before `valueFrom` is applied, so `inputs.input_reads2` inside `when` is the raw `bwa_payload` record rather than the extracted `File?`
- Added `hasAdapter` helper with null/empty/`"unspecified"` guards on adapter string inputs
- `needsR2` detection reads `payload.mates_file` and `payload.interleaved` directly from the record to match the shape Cavatica exposes at `when` evaluation time
- Run cutadapt when: R1 adapter is detected AND (SE input OR R2 adapter is also detected for PE/interleaved)
- `cutadapt` adapter inputs sourced exclusively from `fastp_adapter_detect` outputs; manual override inputs retained on the subworkflow for future use

### docs: describe fastp adapter detection and cutadapt gating
- Added paragraph to `KFDRC_SENTIEON_ALIGNMENT_GVCF_WORKFLOW_README.md` covering fastp detection mode, 1M-read sampling limit, JSON/HTML outputs, and adapter-gated cutadapt behavior for PE and interleaved inputs

## Testing on Cavatica

- [with adapters](https://cavatica.sbgenomics.com/u/childrens-bti/impact-wf-dev/tasks/1071b3db-81d7-4dfe-aa12-6b8f52d9d591)
- [w/o adapters](https://cavatica.sbgenomics.com/u/childrens-bti/impact-wf-dev/tasks/7ead2788-1812-42e4-b239-e5a1cdeec93b)
