### PR TITLE
Add fastp adapter safeguards to Sentieon alignment

### DIFF
--- a/docs/KFDRC_SENTIEON_ALIGNMENT_GVCF_WORKFLOW_README.md
+++ b/docs/KFDRC_SENTIEON_ALIGNMENT_GVCF_WORKFLOW_README.md
@@ -59,9 +59,13 @@ Finally, the metrics collection is done with a series of Sentieon algorithms
 that match our existing Picard metrics suite.
 
 Adapter detection is implemented with `fastp` in detection mode on a sampled
-subset of reads (up to 1M by default). This step emits JSON/HTML QC reports
-and extracts detected R1/R2 adapter sequences used to gate `cutadapt` trimming
-for paired-end and interleaved inputs.
+subset of reads (up to 1M by default). This step emits JSON/HTML QC reports.
+Manual `cutadapt_r1_adapter`/`cutadapt_r2_adapter` inputs override detection
+and force `cutadapt` trimming. Without manual adapters, detected adapters are
+used only when fastp reports at least 1% adapter-trimmed bases and the selected
+adapter sequence starts with standard Illumina adapter seeds `AGATCGGA`
+(TruSeq) or `CTGTCTCT` (Nextera). For paired-end or interleaved inputs, both
+R1 and R2 must pass validation; otherwise `cutadapt` is skipped.
 
 | Step                       | KFDRC GATK            | KFDRC Sentieon                    |
 |----------------------------|-----------------------|-----------------------------------|

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -62,7 +62,9 @@ steps:
             var reads_name = self[1].reads_file.basename.replace(/.f(ast)?[aq](\.gz)?$/, "");
             return [basename, (rg_id != null ? rg_id[1] : "UNKNOWN"), reads_name].join('.');
           }
-    out: [fastp_json, fastp_html, r1_adapter, r2_adapter]
+      manual_r1_adapter: cutadapt_r1_adapter
+      manual_r2_adapter: cutadapt_r2_adapter
+    out: [fastp_json, fastp_html, r1_adapter, r2_adapter, run_cutadapt]
 
   cutadapt:
     run: ../tools/cutadapt.cwl
@@ -75,11 +77,13 @@ steps:
           var s = String(v).trim().toLowerCase();
           return s.length > 0 && s !== "unspecified";
         }
-        var payload = inputs.input_reads2;
+
         var r1ok = hasAdapter(inputs.r1_threeprime_adapter);
-        var needsR2 = payload != null && (payload.mates_file != null || payload.interleaved === true);
         var r2ok = hasAdapter(inputs.r2_threeprime_adapter);
-        return r1ok && (!needsR2 || r2ok);
+        var hasMateFile = inputs.input_reads2 != null;
+        var isInterleaved = inputs.interleaved === true;
+
+        return r1ok && (!hasMateFile || r2ok) && (!isInterleaved || r2ok);
       }
     in:
       input_reads1:

--- a/tools/cutadapt.cwl
+++ b/tools/cutadapt.cwl
@@ -18,17 +18,36 @@ requirements:
     ramMin: $(inputs.ram * 1000)
 baseCommand: [cutadapt]
 stdout: $(inputs.outputname_stats)
+arguments:
+  - position: 2
+    shellQuote: false
+    valueFrom: >-
+      ${
+        if (inputs.r2_threeprime_adapter && inputs.r2_threeprime_adapter.trim().length > 0) {
+          return "-A " + inputs.r2_threeprime_adapter;
+        }
+        return "";
+      }
+  - position: 2
+    shellQuote: false
+    valueFrom: >-
+      ${
+        if (inputs.r2_threeprime_adapter && inputs.input_reads2 && inputs.outputname_reads2) {
+          return "--paired-output " + inputs.outputname_reads2;
+        }
+        return "";
+      }
 inputs:
   input_reads1: { type: 'File', inputBinding: { position: 8 }, doc: "FASTQ file containing reads1 or interleaved reads." }
   input_reads2: { type: 'File?', inputBinding: { position: 9 },  doc: "FASTQ file containing reads2." }
   interleaved: { type: 'boolean?', inputBinding: { position: 2, prefix: "--interleaved" }, doc: "Read and/or write interleaved paired-end reads." }
   r1_threeprime_adapter: { type: 'string', inputBinding: { position: 2, prefix: "-a" }, doc: "regular 3' adapter sequence to remove from read1" }
-  r2_threeprime_adapter: { type: 'string?', inputBinding: { position: 2, prefix: "-A" }, doc: "regular 3' adapter sequence to remove from read2" }
+  r2_threeprime_adapter: { type: 'string?', doc: "regular 3' adapter sequence to remove from read2" }
   minimum_length: { type: 'int?', default: 20, inputBinding: { position: 2, prefix: "--minimum-length" }, doc: "If you do not use this option, reads that have a length of zero (empty reads) are kept in the output" }
   quality_base: { type: 'int?', default: 33, inputBinding: { position: 2, prefix: "--quality-base" }, doc: "Phred scale used" }
   quality_cutoff: {type: 'string?', default: "0", inputBinding: { position: 2, prefix: "--quality-cutoff" }, doc: "Quality trim cutoff. If you specify a single cutoff value, the 3' end of each read is trimmed. If you specify two cutoff values separated by a comma, the first value will be trimmed from the 5' and the second value will be trimmed from the 3'" }
   outputname_reads1: { type: 'string?', default: "reads1.trimmed.fastq", inputBinding: { position: 2, prefix: "--output" }, doc: "Write trimmed reads to FILE. Can be FASTQ or FASTA format" }
-  outputname_reads2: { type: 'string?', inputBinding: { position: 2, prefix: "--paired-output" }, doc: "Write R2 to FILE." }
+  outputname_reads2: { type: 'string?', doc: "Write R2 to FILE." }
   outputname_stats: { type: 'string?', default: "cutadapt_stats.txt", doc: "Name for stats output file." }
   additional_args: {type: 'string?', inputBinding: { position: 2, shellQuote: false }, doc: "Any additional args to be set"}
   cpu: { type: 'int?', default: 8, inputBinding: { position: 2, prefix: "--cores" }, doc: "CPUs to allocate to this task" }
@@ -39,8 +58,14 @@ outputs:
     outputBinding:
       glob: $(inputs.outputname_reads1) 
   trimmed_paired_output:
-    type: File
+    type: 'File?'
     outputBinding:
-      glob: $(inputs.outputname_reads2)
+      glob: |
+        ${
+          if (inputs.input_reads2 && inputs.outputname_reads2) {
+            return inputs.outputname_reads2;
+          }
+          return null;
+        }
   cutadapt_stats:
     type: stdout 

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -8,6 +8,12 @@ doc: |
   Processes up to 1M reads by default.
   - For paired-end input: provide reads2 for separate files, or set interleaved=true for interleaved file.
   - Automatically adds --detect_adapter_for_pe when reads2 is provided or interleaved=true.
+  Manual adapters override detected adapters. If no manual R1 adapter is
+  provided, detected adapters are selected for cutadapt only when fastp reports
+  at least 1% adapter-trimmed bases and the detected adapter sequence starts
+  with standard Illumina adapter seeds: AGATCGGA (TruSeq) or CTGTCTCT (Nextera).
+  For paired-end/interleaved reads, both R1 and R2 must pass validation.
+  Otherwise empty adapter files are emitted and cutadapt is skipped downstream.
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
@@ -39,6 +45,12 @@ inputs:
   sample_name:
     type: string
     doc: "Sample name used to name output reports"
+  manual_r1_adapter:
+    type: 'string?'
+    doc: "User-provided R1 adapter. If present and not 'unspecified', it overrides fastp detection."
+  manual_r2_adapter:
+    type: 'string?'
+    doc: "User-provided R2 adapter. Used with manual_r1_adapter when present; 'unspecified' is treated as empty."
   threads:
     type: 'int?'
     default: 4
@@ -78,8 +90,25 @@ arguments:
   - position: 100
     shellQuote: false
     valueFrom: >-
-      && sed -n 's/.*"read1_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json > r1_adapter.txt
-      && sed -n 's/.*"read2_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json > r2_adapter.txt
+      && detected_r1=\$(sed -n 's/.*"read1_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json)
+      && detected_r2=\$(sed -n 's/.*"read2_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json)
+      && adapter_trimmed_bases=\$(awk '/"adapter_trimmed_bases"/ {gsub(/[^0-9]/, "", $0); print; exit}' $(inputs.sample_name).fastp.json)
+      && total_bases=\$(awk '/"before_filtering"/ {in_before=1} in_before && /"total_bases"/ {gsub(/[^0-9]/, "", $0); print; exit}' $(inputs.sample_name).fastp.json)
+      && adapter_pct=\$(awk -v trimmed="$adapter_trimmed_bases" -v total="$total_bases" 'BEGIN {if (total > 0) printf "%.6f", 100 * trimmed / total; else print "0"}')
+      && manual_r1='$(inputs.manual_r1_adapter ? inputs.manual_r1_adapter : "")'
+      && manual_r2='$(inputs.manual_r2_adapter ? inputs.manual_r2_adapter : "")'
+      && manual_r1=\$(printf '%s' "$manual_r1" | awk '{$1=$1; print}')
+      && manual_r2=\$(printf '%s' "$manual_r2" | awk '{$1=$1; print}')
+      && if [ "\$(printf '%s' "$manual_r1" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r1=""; fi
+      && if [ "\$(printf '%s' "$manual_r2" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r2=""; fi
+      && adapter_pct_ok=false
+      && detected_adapters_ok=false
+      && if awk -v pct="$adapter_pct" 'BEGIN {exit pct < 1.0}'; then adapter_pct_ok=true; fi
+      && if printf '%s' "$detected_r1" | grep -qE '^(AGATCGGA|CTGTCTCT)' && { [ -z "$(inputs.interleaved || inputs.reads2 != null ? "paired" : "")" ] || printf '%s' "$detected_r2" | grep -qE '^(AGATCGGA|CTGTCTCT)'; }; then detected_adapters_ok=true; fi
+      && : > r1_adapter.txt
+      && : > r2_adapter.txt
+      && printf 'false\n' > run_cutadapt.txt
+      && if [ -n "$manual_r1" ]; then printf '%s\n' "$manual_r1" > r1_adapter.txt; printf '%s\n' "$manual_r2" > r2_adapter.txt; printf 'true\n' > run_cutadapt.txt; elif [ "$adapter_pct_ok" = true ] && [ "$detected_adapters_ok" = true ]; then printf '%s\n' "$detected_r1" > r1_adapter.txt; printf '%s\n' "$detected_r2" > r2_adapter.txt; printf 'true\n' > run_cutadapt.txt; fi
 
 outputs:
   fastp_json:
@@ -94,15 +123,30 @@ outputs:
       glob: $(inputs.sample_name).fastp.html
   r1_adapter:
     type: 'string?'
-    doc: "Detected R1 adapter sequence (empty file => null)"
+    doc: "Adapter selected for R1 trimming after manual override and fastp safeguards"
     outputBinding:
       glob: r1_adapter.txt
       loadContents: true
-      outputEval: $(self[0].contents.trim() || null)
+      outputEval: |
+        ${
+          var adapter = self[0].contents.replace(/\u0000/g, "").trim();
+          return adapter && adapter.toLowerCase() !== "unspecified" ? adapter : null;
+        }
   r2_adapter:
     type: 'string?'
-    doc: "Detected R2 adapter sequence (empty file => null)"
+    doc: "Adapter selected for R2 trimming after manual override and fastp safeguards"
     outputBinding:
       glob: r2_adapter.txt
       loadContents: true
-      outputEval: $(self[0].contents.trim() || null)
+      outputEval: |
+        ${
+          var adapter = self[0].contents.replace(/\u0000/g, "").trim();
+          return adapter && adapter.toLowerCase() !== "unspecified" ? adapter : null;
+        }
+  run_cutadapt:
+    type: boolean
+    doc: "Whether cutadapt should run based on manual adapters or fastp safeguards"
+    outputBinding:
+      glob: run_cutadapt.txt
+      loadContents: true
+      outputEval: $(self[0].contents.trim() == "true")

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -1,7 +1,7 @@
 cwlVersion: v1.2
 class: Workflow
 id: kfdrc-sentieon-alignment-workflow
-label: Kids First DRC Sentieon Alignment and gVCF Workflow
+label: Kids First DRC Sentieon Alignment and gVCF Workflow (CNH)
 doc: |
   # Kids First Data Resource Center Sentieon Short Reads Alignment and Haplotyper Workflow
 
@@ -63,10 +63,20 @@ doc: |
   Finally, the metrics collection is done with a series of Sentieon algorithms
   that match our existing Picard metrics suite.
 
+  Adapter detection is implemented with `fastp` in detection mode on a sampled
+  subset of reads (up to 1M by default). This step emits JSON/HTML QC reports.
+  Manual `cutadapt_r1_adapter`/`cutadapt_r2_adapter` inputs override detection
+  and force `cutadapt` trimming. Without manual adapters, detected adapters are
+  used only when fastp reports at least 1% adapter-trimmed bases and the selected
+  adapter sequence starts with standard Illumina adapter seeds `AGATCGGA`
+  (TruSeq) or `CTGTCTCT` (Nextera). For paired-end or interleaved inputs, both
+  R1 and R2 must pass validation; otherwise `cutadapt` is skipped.
+
   | Step                       | KFDRC GATK            | KFDRC Sentieon                    |
   |----------------------------|-----------------------|-----------------------------------|
   | Bam to Read Group (RG) BAM | samtools split        | samtools split                    |
   | RG Bam to Fastq            | biobambam2 bamtofastq | biobambam2 bamtofastq             |
+  | Adapter Detection          | fastp                 | fastp                             |
   | Adapter Trimming           | cutadapt              | cutadapt                          |
   | Fastq to RG Bam            | bwa mem               | Sentieon bwa mem                  |
   | Merge RG Bams              | sambamba merge        | Sentieon ReadWriter               |
@@ -487,5 +497,5 @@ hints:
 - GVCF
 - SENTIEON
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-alignment-workflow-cnh/releases/tag/v1.1.0'
+- id: 'https://github.com/childrens-bti/kf-alignment-workflow-cnh/releases/tag/v1.2.0'
   label: github-release


### PR DESCRIPTION
Closes https://github.com/childrens-bti/kf-alignment-workflow-cnh/issues/10
## Summary
- add fastp adapter detection safeguards with manual adapter override support
- route selected adapters into the Sentieon BWA payload preprocessing path
- preserve original DNA cutadapt gating for paired-end and interleaved reads
- make cutadapt paired output conditional so single-end inputs do not request R2 output
- document fastp detection and trimming behavior in the Sentieon workflow docs

**Testing on Cavatica**
[with adapters]([Kids First DRC Sentieon Alignment and gVCF Workflow run - fastp test (have adapters)](https://cavatica.sbgenomics.com/u/childrens-bti/impact-wf-dev/tasks/e2bd5563-fb0f-49cb-9582-a44f4c9cd694))
[w/o adapters]([Kids First DRC Sentieon Alignment and gVCF Workflow run - fastp test (no adapters)](https://cavatica.sbgenomics.com/u/childrens-bti/impact-wf-dev/tasks/7117fbf1-c156-47c8-a930-985000f17214))