### PR TITLE
Safeguard fastp adapter detection and trimming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ cavatica/
 logs/
 outputs/
 params/
+tests/

--- a/docs/KFDRC_SENTIEON_ALIGNMENT_GVCF_WORKFLOW_README.md
+++ b/docs/KFDRC_SENTIEON_ALIGNMENT_GVCF_WORKFLOW_README.md
@@ -60,12 +60,13 @@ that match our existing Picard metrics suite.
 
 Adapter detection is implemented with `fastp` in detection mode on a sampled
 subset of reads (up to 1M by default). This step emits JSON/HTML QC reports.
-Manual `cutadapt_r1_adapter`/`cutadapt_r2_adapter` inputs override detection
-and force `cutadapt` trimming. Without manual adapters, detected adapters are
-used only when fastp reports at least 1% adapter-trimmed bases and the selected
-adapter sequence starts with standard Illumina adapter seeds `AGATCGGA`
-(TruSeq) or `CTGTCTCT` (Nextera). For paired-end or interleaved inputs, both
-R1 and R2 must pass validation; otherwise `cutadapt` is skipped.
+Manual `cutadapt_r1_adapter`/`cutadapt_r2_adapter` inputs independently
+override detection for each read end. Without a manual adapter, a detected
+sequence is used only when fastp annotates it as an exact member of its built-in
+known-adapter pool. Fastp's less-than-1% warning is informational; known
+adapters are passed to `cutadapt` at any percentage. De novo and unspecified
+detections are rejected. Paired-end and interleaved read ends are evaluated
+independently, and `cutadapt` runs when at least one adapter is selected.
 
 | Step                       | KFDRC GATK            | KFDRC Sentieon                    |
 |----------------------------|-----------------------|-----------------------------------|

--- a/docs/dockers_sentieon_alignment.md
+++ b/docs/dockers_sentieon_alignment.md
@@ -6,7 +6,7 @@ biobambam_bamtofastq.cwl|pgc-images.sbgenomics.com/d3b-bixu/bwa-bundle:dev
 clt_flatten_filelist.cwl|None
 clt_prepare_bwa_payload.cwl|None
 cutadapt.cwl|quay.io/biocontainers/cutadapt:4.6--py310h4b81fae_1
-fastp_adapter_detect.cwl|quay.io/biocontainers/fastp:0.23.4--h5f740d0_0
+fastp_adapter_detect.cwl|quay.io/biocontainers/fastp:1.3.6--h43da1c4_0
 expression_preparerg.cwl|None
 gatk_indexfeaturefile.cwl|pgc-images.sbgenomics.com/d3b-bixu/gatk:4.1.7.0R
 picard_collectgvcfcallingmetrics.cwl|pgc-images.sbgenomics.com/d3b-bixu/picard:2.18.9R

--- a/subworkflows/bwa_payload_to_realn_bam.cwl
+++ b/subworkflows/bwa_payload_to_realn_bam.cwl
@@ -78,12 +78,8 @@ steps:
           return s.length > 0 && s !== "unspecified";
         }
 
-        var r1ok = hasAdapter(inputs.r1_threeprime_adapter);
-        var r2ok = hasAdapter(inputs.r2_threeprime_adapter);
-        var hasMateFile = inputs.input_reads2 != null;
-        var isInterleaved = inputs.interleaved === true;
-
-        return r1ok && (!hasMateFile || r2ok) && (!isInterleaved || r2ok);
+        return hasAdapter(inputs.r1_threeprime_adapter) ||
+          hasAdapter(inputs.r2_threeprime_adapter);
       }
     in:
       input_reads1:

--- a/tools/cutadapt.cwl
+++ b/tools/cutadapt.cwl
@@ -20,28 +20,22 @@ baseCommand: [cutadapt]
 stdout: $(inputs.outputname_stats)
 arguments:
   - position: 2
-    shellQuote: false
+    prefix: -a
     valueFrom: >-
-      ${
-        if (inputs.r2_threeprime_adapter && inputs.r2_threeprime_adapter.trim().length > 0) {
-          return "-A " + inputs.r2_threeprime_adapter;
-        }
-        return "";
-      }
+      $(inputs.r1_threeprime_adapter && inputs.r1_threeprime_adapter.trim().length > 0 ? inputs.r1_threeprime_adapter : null)
   - position: 2
-    shellQuote: false
+    prefix: -A
     valueFrom: >-
-      ${
-        if (inputs.r2_threeprime_adapter && inputs.input_reads2 && inputs.outputname_reads2) {
-          return "--paired-output " + inputs.outputname_reads2;
-        }
-        return "";
-      }
+      $(inputs.r2_threeprime_adapter && inputs.r2_threeprime_adapter.trim().length > 0 ? inputs.r2_threeprime_adapter : null)
+  - position: 2
+    prefix: --paired-output
+    valueFrom: >-
+      $(inputs.input_reads2 && inputs.outputname_reads2 ? inputs.outputname_reads2 : null)
 inputs:
   input_reads1: { type: 'File', inputBinding: { position: 8 }, doc: "FASTQ file containing reads1 or interleaved reads." }
   input_reads2: { type: 'File?', inputBinding: { position: 9 },  doc: "FASTQ file containing reads2." }
   interleaved: { type: 'boolean?', inputBinding: { position: 2, prefix: "--interleaved" }, doc: "Read and/or write interleaved paired-end reads." }
-  r1_threeprime_adapter: { type: 'string', inputBinding: { position: 2, prefix: "-a" }, doc: "regular 3' adapter sequence to remove from read1" }
+  r1_threeprime_adapter: { type: 'string?', doc: "regular 3' adapter sequence to remove from read1" }
   r2_threeprime_adapter: { type: 'string?', doc: "regular 3' adapter sequence to remove from read2" }
   minimum_length: { type: 'int?', default: 20, inputBinding: { position: 2, prefix: "--minimum-length" }, doc: "If you do not use this option, reads that have a length of zero (empty reads) are kept in the output" }
   quality_base: { type: 'int?', default: 33, inputBinding: { position: 2, prefix: "--quality-base" }, doc: "Phred scale used" }

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -1,23 +1,24 @@
 cwlVersion: v1.2
 class: CommandLineTool
 id: fastp_adapter_detect
-label: "fastp v0.23.4 Adapter Detection"
+label: "fastp v1.3.6 Adapter Detection"
 doc: |
   Run fastp to detect adapter sequences and produce JSON and HTML QC reports.
   Trimmed reads are discarded (/tmp); only the reports are used downstream.
   Processes up to 1M reads by default.
   - For paired-end input: provide reads2 for separate files, or set interleaved=true for interleaved file.
   - Automatically adds --detect_adapter_for_pe when reads2 is provided or interleaved=true.
-  Manual adapters override detected adapters. If no manual R1 adapter is
-  provided, detected adapters are selected for cutadapt only when fastp reports
-  at least 1% adapter-trimmed bases and the detected adapter sequence starts
-  with standard Illumina adapter seeds: AGATCGGA (TruSeq) or CTGTCTCT (Nextera).
-  For paired-end/interleaved reads, both R1 and R2 must pass validation.
-  Otherwise empty adapter files are emitted and cutadapt is skipped downstream.
+  Manual adapters override detected adapters independently for each read end.
+  Detected adapters are selected for cutadapt only when fastp annotates the exact
+  sequence as a member of its built-in known-adapter pool. Fastp's less-than-1%
+  adapter-content warning is informational and does not reject a known adapter.
+  De novo or unspecified detections are rejected. Cutadapt runs when at least
+  one read end has a manual or known detected adapter.
+  Paired-end and interleaved read ends are evaluated independently.
 requirements:
   - class: ShellCommandRequirement
   - class: DockerRequirement
-    dockerPull: 'quay.io/biocontainers/fastp:0.23.4--h5f740d0_0'
+    dockerPull: 'quay.io/biocontainers/fastp:1.3.6--h43da1c4_0'
   - class: InlineJavascriptRequirement
   - class: ResourceRequirement
     coresMin: $(inputs.threads)
@@ -92,23 +93,22 @@ arguments:
     valueFrom: >-
       && detected_r1=\$(sed -n 's/.*"read1_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json)
       && detected_r2=\$(sed -n 's/.*"read2_adapter_sequence"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' $(inputs.sample_name).fastp.json)
-      && adapter_trimmed_bases=\$(awk '/"adapter_trimmed_bases"/ {gsub(/[^0-9]/, "", $0); print; exit}' $(inputs.sample_name).fastp.json)
-      && total_bases=\$(awk '/"before_filtering"/ {in_before=1} in_before && /"total_bases"/ {gsub(/[^0-9]/, "", $0); print; exit}' $(inputs.sample_name).fastp.json)
-      && adapter_pct=\$(awk -v trimmed="$adapter_trimmed_bases" -v total="$total_bases" 'BEGIN {if (total > 0) printf "%.6f", 100 * trimmed / total; else print "0"}')
       && manual_r1='$(inputs.manual_r1_adapter ? inputs.manual_r1_adapter : "")'
       && manual_r2='$(inputs.manual_r2_adapter ? inputs.manual_r2_adapter : "")'
       && manual_r1=\$(printf '%s' "$manual_r1" | awk '{$1=$1; print}')
       && manual_r2=\$(printf '%s' "$manual_r2" | awk '{$1=$1; print}')
       && if [ "\$(printf '%s' "$manual_r1" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r1=""; fi
       && if [ "\$(printf '%s' "$manual_r2" | tr '[:upper:]' '[:lower:]')" = "unspecified" ]; then manual_r2=""; fi
-      && adapter_pct_ok=false
-      && detected_adapters_ok=false
-      && if awk -v pct="$adapter_pct" 'BEGIN {exit pct < 1.0}'; then adapter_pct_ok=true; fi
-      && if printf '%s' "$detected_r1" | grep -qE '^(AGATCGGA|CTGTCTCT)' && { [ -z "$(inputs.interleaved || inputs.reads2 != null ? "paired" : "")" ] || printf '%s' "$detected_r2" | grep -qE '^(AGATCGGA|CTGTCTCT)'; }; then detected_adapters_ok=true; fi
+      && detected_r1_known=false
+      && detected_r2_known=false
+      && if [ -n "$detected_r1" ] && grep -Fq "$detected_r1 ->" '$(inputs.sample_name).fastp.html'; then detected_r1_known=true; fi
+      && if [ -n "$(inputs.interleaved || inputs.reads2 != null ? "paired" : "")" ] && [ -n "$detected_r2" ] && grep -Fq "$detected_r2 ->" '$(inputs.sample_name).fastp.html'; then detected_r2_known=true; fi
       && : > r1_adapter.txt
       && : > r2_adapter.txt
       && printf 'false\n' > run_cutadapt.txt
-      && if [ -n "$manual_r1" ]; then printf '%s\n' "$manual_r1" > r1_adapter.txt; printf '%s\n' "$manual_r2" > r2_adapter.txt; printf 'true\n' > run_cutadapt.txt; elif [ "$adapter_pct_ok" = true ] && [ "$detected_adapters_ok" = true ]; then printf '%s\n' "$detected_r1" > r1_adapter.txt; printf '%s\n' "$detected_r2" > r2_adapter.txt; printf 'true\n' > run_cutadapt.txt; fi
+      && if [ -n "$manual_r1" ]; then printf '%s\n' "$manual_r1" > r1_adapter.txt; elif [ "$detected_r1_known" = true ]; then printf '%s\n' "$detected_r1" > r1_adapter.txt; fi
+      && if [ -n "$(inputs.interleaved || inputs.reads2 != null ? "paired" : "")" ]; then if [ -n "$manual_r2" ]; then printf '%s\n' "$manual_r2" > r2_adapter.txt; elif [ "$detected_r2_known" = true ]; then printf '%s\n' "$detected_r2" > r2_adapter.txt; fi; fi
+      && if [ -s r1_adapter.txt ] || [ -s r2_adapter.txt ]; then printf 'true\n' > run_cutadapt.txt; fi
 
 outputs:
   fastp_json:

--- a/tools/fastp_adapter_detect.cwl
+++ b/tools/fastp_adapter_detect.cwl
@@ -20,11 +20,59 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'quay.io/biocontainers/fastp:1.3.6--h43da1c4_0'
   - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: run_fastp
+        entry: |
+          #!/bin/bash
+          set -euo pipefail
+          interleaved=false
+          input=""
+          previous=""
+          for arg in "$@"; do
+            if [[ "$arg" == "--interleaved_in" ]]; then
+              interleaved=true
+            elif [[ "$previous" == "-i" ]]; then
+              input="$arg"
+            fi
+            previous="$arg"
+          done
+          if [[ "$interleaved" == false ]]; then
+            exec fastp "$@"
+          fi
+          threads=""
+          reads_to_process=""
+          html=""
+          json=""
+          out1=""
+          out2=""
+          while [[ "$#" -gt 0 ]]; do
+            case "$1" in
+              -i) input="$2"; shift 2 ;;
+              --thread) threads="$2"; shift 2 ;;
+              --reads_to_process) reads_to_process="$2"; shift 2 ;;
+              -h) html="$2"; shift 2 ;;
+              -j) json="$2"; shift 2 ;;
+              -o) out1="$2"; shift 2 ;;
+              -O) out2="$2"; shift 2 ;;
+              *) shift ;;
+            esac
+          done
+          r1=/tmp/fastp_interleaved_r1.fastq
+          r2=/tmp/fastp_interleaved_r2.fastq
+          if [[ "$input" == *.gz ]]; then
+            gzip -cd -- "$input"
+          else
+            cat -- "$input"
+          fi | awk -v r1="$r1" -v r2="$r2" '{out = (int((NR - 1) / 4) % 2 == 0 ? r1 : r2); print > out}'
+          exec fastp -i "$r1" -I "$r2" --thread "$threads" \
+            --reads_to_process "$reads_to_process" --detect_adapter_for_pe \
+            -h "$html" -j "$json" -o "$out1" -O "$out2"
   - class: ResourceRequirement
     coresMin: $(inputs.threads)
     ramMin: 4000
 
-baseCommand: [fastp]
+baseCommand: [bash, run_fastp]
 
 inputs:
   reads1:
@@ -87,7 +135,7 @@ arguments:
   - position: 9
     prefix: "-O"
     valueFrom: |
-      $(inputs.reads2 != null ? "/tmp/fastp_discard_r2.fastq.gz" : null)
+      $(inputs.reads2 != null || inputs.interleaved ? "/tmp/fastp_discard_r2.fastq.gz" : null)
   - position: 100
     shellQuote: false
     valueFrom: >-

--- a/tools/samtools_idxstats_xy_ratio.cwl
+++ b/tools/samtools_idxstats_xy_ratio.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 id: samtools_index_stats_xy_ratio
 requirements:

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -498,5 +498,5 @@ hints:
 - GVCF
 - SENTIEON
 "sbg:links":
-- id: 'https://github.com/childrens-bti/kf-alignment-workflow-cnh/releases/tag/v1.2.1'
+- id: 'https://github.com/childrens-bti/kf-alignment-workflow-cnh/releases/tag/v1.2.2'
   label: github-release

--- a/workflows/kfdrc_sentieon_alignment_wf.cwl
+++ b/workflows/kfdrc_sentieon_alignment_wf.cwl
@@ -65,12 +65,13 @@ doc: |
 
   Adapter detection is implemented with `fastp` in detection mode on a sampled
   subset of reads (up to 1M by default). This step emits JSON/HTML QC reports.
-  Manual `cutadapt_r1_adapter`/`cutadapt_r2_adapter` inputs override detection
-  and force `cutadapt` trimming. Without manual adapters, detected adapters are
-  used only when fastp reports at least 1% adapter-trimmed bases and the selected
-  adapter sequence starts with standard Illumina adapter seeds `AGATCGGA`
-  (TruSeq) or `CTGTCTCT` (Nextera). For paired-end or interleaved inputs, both
-  R1 and R2 must pass validation; otherwise `cutadapt` is skipped.
+  Manual `cutadapt_r1_adapter`/`cutadapt_r2_adapter` inputs independently
+  override detection for each read end. Without a manual adapter, a detected
+  sequence is used only when fastp annotates it as an exact member of its built-in
+  known-adapter pool. Fastp's less-than-1% warning is informational; known
+  adapters are passed to `cutadapt` at any percentage. De novo and unspecified
+  detections are rejected. Paired-end and interleaved read ends are evaluated
+  independently, and `cutadapt` runs when at least one adapter is selected.
 
   | Step                       | KFDRC GATK            | KFDRC Sentieon                    |
   |----------------------------|-----------------------|-----------------------------------|


### PR DESCRIPTION
## Description

This updates the Sentieon alignment adapter-detection path to:

- Upgrade fastp to 1.3.6 and accept only adapters identified from its known-adapter pool.
- Apply manual and detected adapters independently for R1 and R2.
- Run cutadapt when either read end has a selected adapter.
- Allow optional R1 and R2 adapter arguments in the cutadapt tool.
- Support explicit paired-end adapter detection for interleaved input by temporarily separating R1 and R2 records for fastp; cutadapt still trims the original interleaved FASTQ directly.
- Update the idxstats tool to CWL v1.2 for optional BAM and CRAM index declarations.
- Document the revised behavior and container version.

## Local synthetic tests

Focused simulations exercised `fastp_adapter_detect.cwl` and `cutadapt.cwl` without running alignment, Sentieon, or the complete workflow.

Test configuration:

- fastp 1.3.6
- cutadapt 4.6
- cwltool 3.1.20250110105449
- Deterministic synthetic 100 bp FASTQs
- 12,000 reads or read pairs per scenario
- Known Illumina adapters, an unknown adapter, clean reads, and manual overrides
- Minimum-length filtering disabled so the tests isolate adapter detection and trimming

| Scenario | Expected behavior | Result |
|---|---|---|
| Single-end known adapter | Select R1 adapter and trim reads | Pass |
| Single-end known adapter below 1% of bases | Accept the known adapter despite low abundance | Pass |
| Single-end de novo adapter | Reject the adapter because it is not in fastp's known pool | Pass |
| Single-end clean reads | Return no adapter and skip cutadapt | Pass |
| Paired-end R1 adapter only | Trim R1 and preserve R2 | Pass |
| Paired-end R2 adapter only | Preserve R1 and trim R2 | Pass |
| Paired-end adapters on both mates | Select and trim both adapters | Pass |
| Interleaved paired-end adapters | Detect both adapters and produce correctly ordered interleaved output | Pass |
| Manual R2 adapter only | Use the manual R2 adapter while leaving R1 unset | Pass |
| Case-insensitive `unspecified` inputs | Treat both values as empty and skip cutadapt | Pass |

All 10 scenarios passed. Assertions covered exact adapter selection, independent R1/R2 behavior, the `run_cutadapt` decision, exact trimming, preservation of unaffected mates, FASTQ record counts, and interleaved mate ordering.

### Interleaved fastp checks

Additional direct fastp checks confirmed:

- `--interleaved_in --detect_adapter_for_pe` fails in fastp 1.3.6 because the explicit detector expects a separate R2 input.
- `--interleaved_in` without explicit PE detection can trim realistic overlapping pairs.
- Overlap-derived tails are reported in `read1_adapter_counts` and `read2_adapter_counts`, while `read1_adapter_sequence` and `read2_adapter_sequence` remain `unspecified`.
- The compatibility wrapper enables explicit known-pool detection; cutadapt receives and trims the original interleaved input.

### CWL validation

The following passed `cwltool --validate`:

- `tools/fastp_adapter_detect.cwl`
- `tools/cutadapt.cwl`
- `subworkflows/bwa_payload_to_realn_bam.cwl`
- `workflows/kfdrc_sentieon_alignment_wf.cwl`

The larger workflow retains existing checker warnings for conditional outputs and optional inputs, but validation completed without errors.

## Cavatica testing

- [Workflow run with adapters](https://cavatica.sbgenomics.com/u/childrens-bti/impact-wf-dev/tasks/3cab52c6-2fc0-43ca-8c28-9a66c4ab2461/)
- [Workflow run without adapters](https://cavatica.sbgenomics.com/u/childrens-bti/impact-wf-dev/tasks/c7284b06-8cec-4587-a8da-724285df1b3f/)
